### PR TITLE
LIG-114 configurable endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
 application-logging-angular-service
 ===================================
 
-A service to submit client side logs to the server
+An AngularJS service to submit client side logs to the server (uses AJAX POST).
+
+Exposes the following, all of which require the logging config object:
+
+- exceptionLoggingService
+- applicationLoggingService
+- userErrorReport
+
+The config object to be passed to each service has the following properties:
+
+- LOGGING_TYPE (can be local|remote|none)
+  - local: log to local console only
+  - remote: log to local console and remote endpoint
+  - none: perform no logging
+- REMOTE_LOGGING_ENDPOINT: the full URL to the endpoint where log messages are sent via AJAX POST
+- REMOTE_ERROR_REPORT_ENDPOINT: the full URL to the endpoint where user error reports will be sent via AJAX POST
+
+The config object should be declared as an AngularJS constant named LOGGING_CONFIG.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "app-logger-angular",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "main": "./js/logging.js",
     "description": "Client side logging sent to the server",
     "repository": {

--- a/js/logging.js
+++ b/js/logging.js
@@ -52,7 +52,7 @@ loggingModule.factory(
             }
 
             // check if the config says we should log to the remote, and also if a remote endpoint was specified
-            if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_ENDPOINT) {
+            if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT) {
               // now log server side.
               try{
                   var errorMessage = exception.toString();
@@ -62,7 +62,7 @@ loggingModule.factory(
                   // angular might be fubar'd
                   $.ajax({
                       type: "POST",
-                      url: LOGGING_CONFIG.REMOTE_ENDPOINT + "/clientlogger",
+                      url: LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT,
                       contentType: "application/json",
                       data: angular.toJson({
                           url: $window.location.href,
@@ -98,11 +98,11 @@ loggingModule.factory(
                 }
 
                 // check if the config says we should log to the remote, and also if a remote endpoint was specified
-                if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_ENDPOINT) {
+                if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT) {
                   // send server side
                   $.ajax({
                       type: "POST",
-                      url: LOGGING_CONFIG.REMOTE_ENDPOINT + "/clientlogger",
+                      url: LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT,
                       contentType: "application/json",
                       data: angular.toJson({
                           url: $window.location.href,
@@ -118,10 +118,10 @@ loggingModule.factory(
                 }
 
                 // check if the config says we should log to the remote, and also if a remote endpoint was specified
-                if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_ENDPOINT) {
+                if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT) {
                   $.ajax({
                       type: "POST",
-                      url: LOGGING_CONFIG.REMOTE_ENDPOINT + "/clientlogger",
+                      url: LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT,
                       contentType: "application/json",
                       data: angular.toJson({
                           url: $window.location.href,
@@ -148,10 +148,10 @@ loggingModule.factory(
                 if ($rootScope.user != null) payload.user = $rootScope.user.profile;
 
                 // check if the config says we should log to the remote, and also if a remote endpoint was specified
-                if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_ENDPOINT) {
+                if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_ERROR_REPORT_ENDPOINT) {
                   $.ajax({
                       type: "POST",
-                      url: LOGGING_CONFIG.REMOTE_ENDPOINT + "/usererrorreport",
+                      url: LOGGING_CONFIG.REMOTE_ERROR_REPORT_ENDPOINT,
                       contentType: "application/json",
                       data: angular.toJson(payload)
                   });


### PR DESCRIPTION
Modify the Logging Service so that it now takes a `LOGGING_CONFIG` object as an angular constant.
This is an object rather than a literal, simply so the interface never changes.

You can specify the following:
LOGGING_CONFIG.LOGGING_TYPE = 'none' || 'local' || 'remote'
