### PR TITLE
added annotation for exceptionLoggingService

### DIFF
--- a/js/logging.js
+++ b/js/logging.js
@@ -30,9 +30,9 @@ loggingModule.factory(
  */
 loggingModule.provider(
     "$exceptionHandler",{
-        $get: function(exceptionLoggingService){
+        $get: ['exceptionLoggingService', function(exceptionLoggingService){
             return(exceptionLoggingService);
-        }
+        }]
     }
 );
 


### PR DESCRIPTION
Using logging.js in our application failed when using the uglified version of our app. Debugging showed that all code of logging.js except one already contains manual annotations - just one spot was missing. While I could solve the issue in my build environment, I think this should be changed in logging.js for consistency reasons, and to aid other users...