### PR TITLE
90% - Support all logging levels with threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## 2.0.0 (2016-02-19)
+
+Features:
+
+  - Support all trace, debug, info, warn and error levels.
+  - Use LOGGING_THRESHOLD instead of LOGGING_LEVEL in the config object for clarity, default is info level.
+
+Bugfixes:
+
+  - Use the correct console.xxx version to get the correct icons in the browser console for the log level requested.
+
+## 1.x.x
+
+Initial version

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Exposes the following, all of which require the logging config object:
 The config object to be passed to each service has the following properties:
 
 - LOGGING_THRESHOLD
-  - trace/debug/info/warn/error - the threshold at which to create log entries
+  - trace/debug/info/warn/error (default = info) - the threshold at which to create log entries
 - LOGGING_TYPE (can be local|remote|none)
   - local: log to local console only
   - remote: log to local console and remote endpoint

--- a/README.md
+++ b/README.md
@@ -11,15 +11,14 @@ Exposes the following, all of which require the logging config object:
 
 The config object to be passed to each service has the following properties:
 
+- LOGGING_THRESHOLD
+  - trace/debug/info/warn/error - the threshold at which to create log entries
 - LOGGING_TYPE (can be local|remote|none)
   - local: log to local console only
   - remote: log to local console and remote endpoint
   - none: perform no logging
 - REMOTE_LOGGING_ENDPOINT: the full URL to the endpoint where log messages are sent via AJAX POST
 - REMOTE_ERROR_REPORT_ENDPOINT: the full URL to the endpoint where user error reports will be sent via AJAX POST
-- LOGGING_LEVEL (can be debug|error)
-  - debug: log both debug and error messages
-  - error: only log error messages (debug messages are not logged)
 
 The config object should be declared as an AngularJS constant named LOGGING_CONFIG.
 
@@ -27,9 +26,9 @@ Example use of LOGGING_CONFIG:
 
 ```javascript
 // config object for application logger
-config.LOGGING_CONFIG = { 
+config.LOGGING_CONFIG = {
+  LOGGING_THRESHOLD: 'info',
   LOGGING_TYPE: 'local', 
   REMOTE_LOGGING_ENDPOINT: config.TDC_ENDPOINT + "/clientlogger", 
-  REMOTE_ERROR_REPORT_ENDPOINT: config.TDC_ENDPOINT + "/usererrorreport", 
-  LOGGING_LEVEL: "debug" };
+  REMOTE_ERROR_REPORT_ENDPOINT: config.TDC_ENDPOINT + "/usererrorreport" 
 ```

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "app-logger-angular",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "main": "./js/logging.js",
     "description": "Client side logging sent to the server",
     "repository": {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "app-logger-angular",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "main": "./js/logging.js",
     "description": "Client side logging sent to the server",
     "repository": {

--- a/js/logging.js
+++ b/js/logging.js
@@ -1,18 +1,20 @@
 'use strict';
 
 /**
- * this module does a number of things:
- * - first it overrides the built in angular exception handling, so that any exceptions that would normally be logged
- *   to the console, are POSTed via Ajax to a serverside service. It does the cross browser, by using stacktrace.js
- * - second it exposes an applicationLoggingService that can be injected into any angular module. This service exposes
- *   and 'error' and 'debug' methods which if called will log to the console but also send those messages to a serverside
- *   service.
+ * This module does a number of things:
+ *
+ * - It overrides the built in Angular exception handling, so that any exceptions that would normally be logged
+ *   to the console, are POSTed via AJAX to a server-side service. It does the cross-browser, by using stacktrace.js
+ *
+ * - It exposes an applicationLoggingService that can be injected into any Angular module. This service exposes
+ *   'trace', 'debug', 'info', 'warn' and 'error' methods which will log to the console but also send those messages
+ *   to a server-side service.
  */
 var loggingModule = angular.module('talis.services.logging', []);
 
 /**
  * Create a service that gives us a nice Angular-esque wrapper around the
- * stackTrace.js pintStackTrace() method. We use a service because calling
+ * stackTrace.js printStackTrace() method. We use a service because calling
  * methods in the global context is not the 'angular way'
  */
 loggingModule.factory(
@@ -25,8 +27,7 @@ loggingModule.factory(
 );
 
 /**
- * Override Angular's built in exception handler, and tell it to use our new
- * exceptionLoggingService
+ * Override Angular's built in exception handler, and tell it to use our new exceptionLoggingService
  */
 loggingModule.provider(
     "$exceptionHandler",{
@@ -37,45 +38,44 @@ loggingModule.provider(
 );
 
 /**
- * Exception Logging Service, currently only used by the $exceptionHandler
- * but logs to the console and uses the stacktraceService to generate a browser independent stacktrace
- * which is POSTed to server side clientlogging service.
+ * Exception Logging Service, currently only used by the $exceptionHandler but logs to the console and uses the
+ * stacktraceService to generate a browser independent stacktrace which is POSTed to server side clientlogging
+ * service.
  */
 loggingModule.factory(
     "exceptionLoggingService",
     ["$log","$window", "stacktraceService", "LOGGING_CONFIG", function($log, $window, stacktraceService, LOGGING_CONFIG){
         function error( exception, cause){
-
             if (LOGGING_CONFIG.LOGGING_TYPE !== 'none') {
-              // preserve default behaviour i.e. dump to browser console
-              $log.error.apply($log, arguments);
+                // preserve default behaviour i.e. dump to browser console
+                $log.error.apply($log, arguments);
             }
 
             // check if the config says we should log to the remote, and also if a remote endpoint was specified
             if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT) {
-              // now log server side.
-              try{
-                  var errorMessage = exception.toString();
-                  var stackTrace = stacktraceService.print({e: exception});
+                // now log server side.
+                try {
+                    var errorMessage = exception.toString();
+                    var stackTrace = stacktraceService.print({e: exception});
 
-                  // use AJAX not an angular service because if something has gone wrong
-                  // angular might be fubar'd
-                  $.ajax({
-                      type: "POST",
-                      url: LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT,
-                      contentType: "application/json",
-                      data: angular.toJson({
-                          url: $window.location.href,
-                          message: errorMessage,
-                          type: "exception",
-                          stackTrace: stackTrace,
-                          cause: ( cause || "")
-                      })
-                  });
-              } catch (loggingError){
-                  $log.warn("Error logging failed");
-                  $log.log(loggingError);
-              }
+                    // use AJAX not an angular service because if something has gone wrong
+                    // angular might be fubar'd
+                    $.ajax({
+                        type: "POST",
+                        url: LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT,
+                        contentType: "application/json",
+                        data: angular.toJson({
+                            url: $window.location.href,
+                            message: errorMessage,
+                            type: "exception",
+                            stackTrace: stackTrace,
+                            cause: ( cause || "")
+                        })
+                    });
+                } catch (loggingError) {
+                    $log.warn("Error logging failed");
+                    $log.log(loggingError);
+                }
             }
         }
         return( error );
@@ -90,50 +90,71 @@ loggingModule.factory(
 loggingModule.factory(
     "applicationLoggingService",
     ["$log","$window", "LOGGING_CONFIG", function($log, $window, LOGGING_CONFIG){
+        var arrLoggingLevels = ['trace', 'debug', 'info', 'warn', 'error'];
+
+        var loggingThreshold = LOGGING_CONFIG.LOGGING_THRESHOLD || 'info';
+        console.error('APPLOGGER - LOGGING_THRESHOLD = ', loggingThreshold);
+
+        var iLoggingThreshold = arrLoggingLevels.indexOf(loggingThreshold);
+
+        var isLoggingEnabledForSeverity = function(severity) {
+            var iRequestedLevel = arrLoggingLevels.indexOf(severity);
+            if (iRequestedLevel === -1) {
+                // Invalid level requested
+                return false;
+            }
+
+            return (iRequestedLevel >= iLoggingThreshold);
+        }
+
+        var log = function(severity, message, desc) {
+            if (!isLoggingEnabledForSeverity(severity)) {
+                return;
+            }
+
+            if (LOGGING_CONFIG.LOGGING_TYPE !== 'none') {
+                // preserve default behaviour
+                var angularLogSeverity = severity;
+                if (angularLogSeverity === 'trace') {
+                    // Angular $log doesn't support trace so we use 'log' instead.
+                    angularLogSeverity = 'log';
+                }
+
+                $log[angularLogSeverity].apply($log, [message]);
+            }
+
+            // check if the config says we should log to the remote, and also if a remote endpoint was specified
+            if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT) {
+                // send server side
+                $.ajax({
+                    type: "POST",
+                    url: LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT,
+                    contentType: "application/json",
+                    data: angular.toJson({
+                        type: severity,
+                        url: $window.location.href,
+                        message: message,
+                        desc: desc
+                    })
+                });
+            }
+        };
+
         return({
-            error: function(message, desc){
-                if (LOGGING_CONFIG.LOGGING_TYPE !== 'none') {
-                  // preserve default behaviour
-                  $log.error.apply($log, [message]);
-                }
-
-                // check if the config says we should log to the remote, and also if a remote endpoint was specified
-                if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT) {
-                  // send server side
-                  $.ajax({
-                      type: "POST",
-                      url: LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT,
-                      contentType: "application/json",
-                      data: angular.toJson({
-                          url: $window.location.href,
-                          message: message,
-                          type: "error",
-                          desc: desc
-                      })
-                  });
-                }
+            trace: function(message, desc) {
+                log('trace', message, desc);
             },
-            debug: function(message, desc){
-                if (LOGGING_CONFIG.LOGGING_LEVEL !== 'error') {
-                  if (LOGGING_CONFIG.LOGGING_TYPE !== 'none') {
-                    $log.log.apply($log, [message]);
-                  }
-
-                  // check if the config says we should log to the remote, and also if a remote endpoint was specified
-                  if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT) {
-                    $.ajax({
-                        type: "POST",
-                        url: LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT,
-                        contentType: "application/json",
-                        data: angular.toJson({
-                            url: $window.location.href,
-                            message: message,
-                            type: "debug",
-                            desc: desc
-                        })
-                    });
-                  }
-                }
+            debug: function(message, desc) {
+                log('debug', message, desc);
+            },
+            info: function(message, desc) {
+                log('info', message, desc);
+            },
+            warn: function(message, desc) {
+                log('warn', message, desc);
+            },
+            error: function(message, desc) {
+                log('error', message, desc);
             }
         });
     }]
@@ -153,12 +174,12 @@ loggingModule.factory(
 
                 // check if the config says we should log to the remote, and also if a remote endpoint was specified
                 if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_ERROR_REPORT_ENDPOINT) {
-                  $.ajax({
-                      type: "POST",
-                      url: LOGGING_CONFIG.REMOTE_ERROR_REPORT_ENDPOINT,
-                      contentType: "application/json",
-                      data: angular.toJson(payload)
-                  });
+                    $.ajax({
+                        type: "POST",
+                        url: LOGGING_CONFIG.REMOTE_ERROR_REPORT_ENDPOINT,
+                        contentType: "application/json",
+                        data: angular.toJson(payload)
+                    });
                 }
             }
         });

--- a/js/logging.js
+++ b/js/logging.js
@@ -93,7 +93,6 @@ loggingModule.factory(
         var arrLoggingLevels = ['trace', 'debug', 'info', 'warn', 'error'];
 
         var loggingThreshold = LOGGING_CONFIG.LOGGING_THRESHOLD || 'info';
-        console.error('APPLOGGER - LOGGING_THRESHOLD = ', loggingThreshold);
 
         var iLoggingThreshold = arrLoggingLevels.indexOf(loggingThreshold);
 


### PR DESCRIPTION
Previously this service only supported 'debug' and 'error' levels and it was a boolean thing.  Now it supports trace, debug, info, warn and error with a new config property of LOGGING_THRESHOLD to determine which log entries get created (LOGGING_LEVEL has been removed to avoid confusion).  If no LOGGING_THRESHOLD is passed on the config object it will default to 'info' level.

This now also does the correct 'console.xxx' method for the log level in question so you get the correct icon in the browser console.