### PR TITLE
90% - Allow override of logging threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0 (2016-02-23)
+
+Features:
+
+  - Allow override of the logging threshold by calling applicationLoggingService.setLoggingThreshold(level)
+
 ## 2.0.0 (2016-02-19)
 
 Features:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "app-logger-angular",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "main": "./js/logging.js",
     "description": "Client side logging sent to the server",
     "repository": {

--- a/js/logging.js
+++ b/js/logging.js
@@ -91,9 +91,7 @@ loggingModule.factory(
     "applicationLoggingService",
     ["$log","$window", "LOGGING_CONFIG", function($log, $window, LOGGING_CONFIG){
         var arrLoggingLevels = ['trace', 'debug', 'info', 'warn', 'error'];
-
         var loggingThreshold = LOGGING_CONFIG.LOGGING_THRESHOLD || 'info';
-
         var iLoggingThreshold = arrLoggingLevels.indexOf(loggingThreshold);
 
         var isLoggingEnabledForSeverity = function(severity) {
@@ -154,6 +152,16 @@ loggingModule.factory(
             },
             error: function(message, desc) {
                 log('error', message, desc);
+            },
+            setLoggingThreshold: function(level) {
+                /*
+                 * Normally the logger would use the logging threshold passed in on the config hash but an
+                 * application may want to override this dynamically, e.g. to enable a different logging
+                 * threshold for a given user.
+                 */
+                if (arrLoggingLevels.indexOf(level) !== -1) {
+                    iLoggingThreshold = arrLoggingLevels.indexOf(level);
+                }
             }
         });
     }]


### PR DESCRIPTION
Normally the logging threshold would be set via the config hash but some applications may want to set the logging threshold on the fly, e.g enable more verbose logging for a given user.  This provides a function on applicationLoggingService to set the logging threshold dynamically.