### PR TITLE
90% - If overriding logging threshold pass it back to remote logging URL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.1 (2016-02-24)
+
+Bug fix:
+
+  - If overriding the logging threshold dynamically, also pass this value back to the remote logging URL.
+
 ## 2.1.0 (2016-02-23)
 
 Features:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "app-logger-angular",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "main": "./js/logging.js",
     "description": "Client side logging sent to the server",
     "repository": {

--- a/js/logging.js
+++ b/js/logging.js
@@ -94,6 +94,12 @@ loggingModule.factory(
         var loggingThreshold = LOGGING_CONFIG.LOGGING_THRESHOLD || 'info';
         var iLoggingThreshold = arrLoggingLevels.indexOf(loggingThreshold);
 
+        /*
+         * If we've told applicationLoggingService to override the logging threshold set in config then also pass
+         * it back to the remote client logging URL.
+         */
+        var overrideLoggingThreshold = false;
+
         var isLoggingEnabledForSeverity = function(severity) {
             var iRequestedLevel = arrLoggingLevels.indexOf(severity);
             if (iRequestedLevel === -1) {
@@ -131,7 +137,8 @@ loggingModule.factory(
                         type: severity,
                         url: $window.location.href,
                         message: message,
-                        desc: desc
+                        desc: desc,
+                        overrideLoggingThreshold: overrideLoggingThreshold
                     })
                 });
             }
@@ -161,6 +168,7 @@ loggingModule.factory(
                  */
                 if (arrLoggingLevels.indexOf(level) !== -1) {
                     iLoggingThreshold = arrLoggingLevels.indexOf(level);
+                    overrideLoggingThreshold = true;
                 }
             }
         });


### PR DESCRIPTION
If we have overridden the logging threshold dynamically then also pass the level back to the remote logging URL so that can decide if it wants to do anything differently also.