### PR TITLE
90% - LIG-1080 - Allow setting of default data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.4 (2016-11-01)
+
+Improvement:
+
+  - Add setDefaultData(obj) to allow certain data to be logged on every logger call. (e.g. logging of user details)
+
 ## 2.1.3 (2016-10-26)
 
 Bug fix:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "app-logger-angular",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "main": "./js/logging.js",
     "description": "Client side logging sent to the server",
     "repository": {

--- a/js/logging.js
+++ b/js/logging.js
@@ -100,6 +100,12 @@ loggingModule.factory(
          */
         var overrideLoggingThreshold = false;
 
+        /*
+         * Allows the calling code to set some default data that will get logged on
+         * every call to applicationLoggingService.
+         */
+        var defaultData = null;
+
         var isLoggingEnabledForSeverity = function(severity) {
             var iRequestedLevel = arrLoggingLevels.indexOf(severity);
             if (iRequestedLevel === -1) {
@@ -142,6 +148,7 @@ loggingModule.factory(
                         url: $window.location.href,
                         message: message,
                         desc: desc,
+                        defaultData: defaultData,
                         overrideLoggingThreshold: overrideLoggingThreshold
                     })
                 });
@@ -174,6 +181,9 @@ loggingModule.factory(
                     iLoggingThreshold = arrLoggingLevels.indexOf(level);
                     overrideLoggingThreshold = true;
                 }
+            },
+            setDefaultData: function(data) {
+                defaultData = data;
             }
         });
     }]


### PR DESCRIPTION
This allows an object to to set on the service that is default data for each logging call. (E.g. if you want to log user details from the calling app).  This doesn't get output in the browser console (as there's no point) but it does get output to the remote logging endpoint so that the calling app can log it however it wishes.