### PR TITLE
ELE-2170 New Relic support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.6 (2019-12-2)
+
+Improvement:
+
+ - Added support for NewRelic logging so errors can be sent there if needed
+
 ## 2.1.4 (2016-11-01)
 
 Improvement:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The config object to be passed to each service has the following properties:
 - LOGGING_TYPE (can be local|remote|none)
   - local: log to local console only
   - remote: log to local console and remote endpoint
+  - newrelic: forward onto the NewRelic error handler if there's one available
   - none: perform no logging
 - REMOTE_LOGGING_ENDPOINT: the full URL to the endpoint where log messages are sent via AJAX POST
 - REMOTE_ERROR_REPORT_ENDPOINT: the full URL to the endpoint where user error reports will be sent via AJAX POST

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "app-logger-angular",
-    "version": "2.1.5",
+    "version": "2.1.6",
     "main": "./js/logging.js",
     "description": "Client side logging sent to the server",
     "repository": {

--- a/js/logging.js
+++ b/js/logging.js
@@ -49,6 +49,10 @@ loggingModule.factory(
                 $log.error.apply($log, arguments);
             }
 
+            if ( LOGGING_CONFIG.LOGGING_TYPE === 'newrelic' && $window.NREUM && $window.NREUM.noticeError ) {
+                $window.NREUM.noticeError(exception);
+            }
+
             // check if the config says we should log to the remote, and also if a remote endpoint was specified
             if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_LOGGING_ENDPOINT) {
                 // now log server side.

--- a/js/logging.js
+++ b/js/logging.js
@@ -49,7 +49,7 @@ loggingModule.factory(
                 $log.error.apply($log, arguments);
             }
 
-            if ( LOGGING_CONFIG.LOGGING_TYPE === 'newrelic' && $window.NREUM && $window.NREUM.noticeError ) {
+            if (LOGGING_CONFIG.LOGGING_TYPE === 'newrelic' && $window.NREUM && $window.NREUM.noticeError) {
                 $window.NREUM.noticeError(exception);
             }
 


### PR DESCRIPTION
The exception handler currently swallows all errors which prevents the NewRelic error handler from picking them up.

This PR adds a new logging type so errors can be sent off to NewRelic.