### PR TITLE
ELE-3188 Make NewRelic work in addition to existing remote logging.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "app-logger-angular",
-    "version": "2.1.6",
+    "version": "2.1.7",
     "main": "./js/logging.js",
     "description": "Client side logging sent to the server",
     "repository": {

--- a/js/logging.js
+++ b/js/logging.js
@@ -49,7 +49,7 @@ loggingModule.factory(
                 $log.error.apply($log, arguments);
             }
 
-            if (LOGGING_CONFIG.LOGGING_TYPE === 'newrelic' && $window.NREUM && $window.NREUM.noticeError) {
+            if (LOGGING_CONFIG.FORWARD_TO_NEWRELIC && $window.NREUM && $window.NREUM.noticeError) {
                 $window.NREUM.noticeError(exception);
             }
 
@@ -137,6 +137,10 @@ loggingModule.factory(
                 } else {
                     $log[angularLogSeverity](message);
                 }
+            }
+
+            if (LOGGING_CONFIG.FORWARD_TO_NEWRELIC && $window.NREUM && $window.NREUM.noticeError) {
+                $window.NREUM.noticeError(message, {desc: desc});
             }
 
             // check if the config says we should log to the remote, and also if a remote endpoint was specified


### PR DESCRIPTION
Re-worked NewRelic support so it now relies on a new flag that must be set.
It also now works in addition to any remote logging that is configured instead of replacing it
Finally, the error method now pipes errors through to NewRelic so it no longer just works for uncaught exceptions