### PR TITLE
ELE-3188 only errors should go into NewRelic

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "app-logger-angular",
-    "version": "2.1.7",
+    "version": "2.1.8",
     "main": "./js/logging.js",
     "description": "Client side logging sent to the server",
     "repository": {

--- a/js/logging.js
+++ b/js/logging.js
@@ -118,7 +118,7 @@ loggingModule.factory(
             return (iRequestedLevel >= iLoggingThreshold);
         };
 
-        var log = function (severity, message, desc) {
+        var log = function (severity, message, desc, sendToNewRelic) {
             if (!isLoggingEnabledForSeverity(severity)) {
                 return;
             }
@@ -139,7 +139,7 @@ loggingModule.factory(
                 }
             }
 
-            if (LOGGING_CONFIG.FORWARD_TO_NEWRELIC && $window.NREUM && $window.NREUM.noticeError) {
+            if (sendToNewRelic && $window.NREUM && $window.NREUM.noticeError) {
                 $window.NREUM.noticeError(message, {desc: desc});
             }
 
@@ -181,7 +181,8 @@ loggingModule.factory(
                 log('warn', message, desc);
             },
             error: function (message, desc) {
-                log('error', message, desc);
+                var sendToNewRelic = LOGGING_CONFIG.FORWARD_TO_NEWRELIC && $window.NREUM && $window.NREUM.noticeError;
+                log('error', message, desc, sendToNewRelic);
             },
             setLoggingThreshold: function (level) {
                 /*


### PR DESCRIPTION
Added a new parameter to the log function to specifically tell the logger to send the message to NewRelic.

This avoids all messages from being reported there as errors