### PR TITLE
ELE-3189 Callback check to allow errors to be filtered

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "app-logger-angular",
-    "version": "2.1.8",
+    "version": "2.2.0",
     "main": "./js/logging.js",
     "description": "Client side logging sent to the server",
     "repository": {

--- a/js/logging.js
+++ b/js/logging.js
@@ -128,7 +128,6 @@ loggingModule.factory(
                 return;
             }
 
-
             if (LOGGING_CONFIG.LOGGING_TYPE !== 'none') {
                 // preserve default behaviour
                 var angularLogSeverity = severity;

--- a/js/logging.js
+++ b/js/logging.js
@@ -49,6 +49,10 @@ loggingModule.factory(
                 $log.error.apply($log, arguments);
             }
 
+            if($window.talisLogger.onBeforeLogError && !$window.talisLogger.onBeforeLogError(exception)) {
+                return false;
+            }
+
             if (LOGGING_CONFIG.FORWARD_TO_NEWRELIC && $window.NREUM && $window.NREUM.noticeError) {
                 $window.NREUM.noticeError(exception);
             }
@@ -95,6 +99,7 @@ loggingModule.factory(
         var arrLoggingLevels = ['trace', 'debug', 'info', 'warn', 'error'];
         var loggingThreshold = LOGGING_CONFIG.LOGGING_THRESHOLD || 'info';
         var iLoggingThreshold = arrLoggingLevels.indexOf(loggingThreshold);
+        $window.talisLogger = {};
 
         /*
          * If we've told applicationLoggingService to override the logging threshold set in config then also pass
@@ -123,6 +128,7 @@ loggingModule.factory(
                 return;
             }
 
+
             if (LOGGING_CONFIG.LOGGING_TYPE !== 'none') {
                 // preserve default behaviour
                 var angularLogSeverity = severity;
@@ -137,6 +143,10 @@ loggingModule.factory(
                 } else {
                     $log[angularLogSeverity](message);
                 }
+            }
+
+            if($window.talisLogger.onBeforeLogError && !$window.talisLogger.onBeforeLogError(message)) {
+                return false;
             }
 
             if (sendToNewRelic && $window.NREUM && $window.NREUM.noticeError) {


### PR DESCRIPTION
Not all errors are equal and some of them can be ignored, to provide support for this a filter can be attached to `$window.talisLogger.onBeforeLogError` which will run before any errors are sent and, depending on the response from the function, prevent the error from being logged.
