### PR TITLE
ELE-3421 Include URL in NewRelic error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.1 (2020-10-23)
+
+Improvement:
+
+ - Log the browser URL when logging errors and exceptions
+
 ## 2.1.6 (2019-12-2)
 
 Improvement:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "app-logger-angular",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "main": "./js/logging.js",
     "description": "Client side logging sent to the server",
     "repository": {

--- a/js/logging.js
+++ b/js/logging.js
@@ -54,7 +54,7 @@ loggingModule.factory(
             }
 
             if (LOGGING_CONFIG.FORWARD_TO_NEWRELIC && $window.NREUM && $window.NREUM.noticeError) {
-                $window.NREUM.noticeError(exception);
+                $window.NREUM.noticeError(exception, { url: $window.location.href });
             }
 
             // check if the config says we should log to the remote, and also if a remote endpoint was specified
@@ -149,7 +149,7 @@ loggingModule.factory(
             }
 
             if (sendToNewRelic && $window.NREUM && $window.NREUM.noticeError) {
-                $window.NREUM.noticeError(message, {desc: desc});
+                $window.NREUM.noticeError(message, { desc: desc, url: $window.location.href });
             }
 
             // check if the config says we should log to the remote, and also if a remote endpoint was specified


### PR DESCRIPTION
This change ensures the URL is sent as a custom attribute to NewRelic when error messages and exceptions are logged.

Part of talis/elevate-app#3421