### PR TITLE
Include user GUID in error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.2 (2020-10-23)
+
+Improvement:
+
+ - Include the user GUID when sending error reports
+
 ## 2.2.1 (2020-10-23)
 
 Improvement:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "app-logger-angular",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "main": "./js/logging.js",
     "description": "Client side logging sent to the server",
     "repository": {

--- a/js/logging.js
+++ b/js/logging.js
@@ -221,7 +221,10 @@ loggingModule.factory(
                     systemError: error,
                     userMessage: userMessage
                 };
-                if ($rootScope.user != null) payload.user = $rootScope.user.profile;
+                if ($rootScope.user != null) {
+                    payload.user = $rootScope.user.profile;
+                    payload.user.guid = $rootScope.user.guid;
+                }
 
                 // check if the config says we should log to the remote, and also if a remote endpoint was specified
                 if (LOGGING_CONFIG.LOGGING_TYPE === 'remote' && LOGGING_CONFIG.REMOTE_ERROR_REPORT_ENDPOINT) {


### PR DESCRIPTION
When a user submits an error report, it is sent via this service.  We automatically include a user profile in the report if it is available, but not their GUID.  This change includes that, when available.

This will help with talis/elevate-app#3835